### PR TITLE
d3.time.format update

### DIFF
--- a/static/js/graphs.js
+++ b/static/js/graphs.js
@@ -7,7 +7,7 @@ function makeGraphs(error, projectsJson, statesJson) {
 	
 	//Clean projectsJson data
 	var donorschooseProjects = projectsJson;
-	var dateFormat = d3.time.format("%Y-%m-%d");
+	var dateFormat = d3.time.format("%Y-%m-%d %H:%M:%S");
 	donorschooseProjects.forEach(function(d) {
 		d["date_posted"] = dateFormat.parse(d["date_posted"]);
 		d["date_posted"].setDate(1);


### PR DESCRIPTION
d3 graphs will break with trying to fit "year-month-day hour:min:sec" datetime data into the "%Y-%m-%d" format. 

d3.time.format("%Y-%m-%d %H:%M:%S") must be added.
