### PR TITLE
Fixes #7

### DIFF
--- a/static/js/graphs.js
+++ b/static/js/graphs.js
@@ -7,7 +7,7 @@ function makeGraphs(error, projectsJson, statesJson) {
 	
 	//Clean projectsJson data
 	var donorschooseProjects = projectsJson;
-	var dateFormat = d3.time.format("%Y-%m-%d");
+	var dateFormat = d3.time.format("%Y-%m-%d %H:%M:%S");
 	donorschooseProjects.forEach(function(d) {
 		d["date_posted"] = dateFormat.parse(d["date_posted"]);
 		d["date_posted"].setDate(1);


### PR DESCRIPTION
This bug was caused as d3 wasn't able to parse the datetime for
the format "%Y-m-%d" as the actual datetime in the mongoDB data
was of the format "%Y-%m-%d %H:%M:%S" rendering `d["date_posted"]`
as undefined or null, and calling a `setDate` on undefined was
throwing an exception.
